### PR TITLE
Disable variables without render config

### DIFF
--- a/src/components/DataSelector/VariablesSelect/CubeVariablesSelect.tsx
+++ b/src/components/DataSelector/VariablesSelect/CubeVariablesSelect.tsx
@@ -10,6 +10,7 @@ type FormValues = {
 
 function CubeVariablesSelect({ collection, addLayer }: SelectProps) {
   const cubeVariables = collection.stac['cube:variables'];
+  const renderOptions = Object.keys(collection.stac['renders'])
   const { time } = collection.stac['cube:dimensions'];
   const [ timeMin ] = time.extent;
 
@@ -42,7 +43,13 @@ function CubeVariablesSelect({ collection, addLayer }: SelectProps) {
             <RadioGroup {...field}>
               <Stack direction="column">
                 {Object.keys(cubeVariables).map((variable) => (
-                  <Radio value={variable} key={variable}>{ variable }</Radio>
+                  <Radio
+                    value={variable}
+                    key={variable}
+                    isDisabled={!renderOptions.includes(variable)}
+                  >
+                    { variable }
+                  </Radio>
                 ))}
               </Stack>
             </RadioGroup>


### PR DESCRIPTION
If a variable has no corresponding configuration in the render object, the disable the option in the variables form because we not able to render the data.