### PR TITLE
Add URL to renders parameters for other variables

### DIFF
--- a/public/stac/GPM_3IMERGDF_pyramid.stac.json
+++ b/public/stac/GPM_3IMERGDF_pyramid.stac.json
@@ -302,7 +302,8 @@
                     50
                 ]
             ],
-            "backend": "xarray"
+            "backend": "xarray",
+            "url": "s3://nasa-eodc-public/GPM_3IMERGDF.07"
         },
         "randomError": {
             "title": "Renders configuration for randomError",
@@ -315,7 +316,8 @@
                     17469
                 ]
             ],
-            "backend": "xarray"
+            "backend": "xarray",
+            "url": "s3://nasa-eodc-public/GPM_3IMERGDF.07"
         }
     },
     "extent": {


### PR DESCRIPTION
🤦🏽‍♀️ These layers were not working for the GPM IMERG pyramid because the URL parameter is missing.